### PR TITLE
Uses DB.getDataSource instead of constructing one from config values.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,7 @@
 import com.typesafe.sbt.SbtScalariform.scalariformSettings
 import sbt._
 import Keys._
+import play.Project._
 
 object ApplicationBuild extends Build {
 
@@ -15,6 +16,7 @@ object ApplicationBuild extends Build {
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play" % "2.2.0" % "provided",
+        "com.typesafe.play" %% "play-jdbc" % "2.2.0" % "provided",
         "com.googlecode.flyway" % "flyway-core" % "2.3",
         "org.scalatest" %% "scalatest" % "2.0" % "test"
       ),
@@ -24,6 +26,7 @@ object ApplicationBuild extends Build {
   )
 
   val appDependencies = Seq(
+    jdbc,
     "com.h2database" % "h2" % "[1.3,)",
     "postgresql" % "postgresql" % "9.1-901.jdbc4",
     "com.github.seratch" %% "scalikejdbc" % "1.5.2" % "test",


### PR DESCRIPTION
The reason for the change is that DB.createDataSource does some trick on "url" for specific DB drivers, and I want to use that.

On Heroku, the database URL should be passed as a command line parameter like the following:

```
web: target/universal/stage/bin/projectname -Dhttp.port=${PORT} -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
```

And the DATABASE_URL starts with `postgres://`, not `jdbc:postgresql://`
