### PR TITLE
Delay initialization

### DIFF
--- a/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
+++ b/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
@@ -51,7 +51,7 @@ class Plugin(implicit app: Application) extends play.api.Plugin
     }
   }
 
-  private val flyways: Map[String, Flyway] = {
+  private lazy val flyways: Map[String, Flyway] = {
     for {
       (dbName, configuration) <- configReader.getDatabaseConfigurations
       migrationFilesLocation = s"db/migration/${dbName}"


### PR DESCRIPTION
This change avoids initializing when the plugin is disabled.

This is specially beneficial when running tests with migrations disabled.
Hundreds of initialization checks are avoided, along with the debug
notices that accompany them.

There is no effect when the plugin is enabled.
