### PR TITLE
Adds configurable outOfOrder parameter to flyway

### DIFF
--- a/plugin/src/main/scala/com/github/tototoshi/play2/flyway/ConfigReader.scala
+++ b/plugin/src/main/scala/com/github/tototoshi/play2/flyway/ConfigReader.scala
@@ -46,4 +46,8 @@ class ConfigReader(app: Application) extends UrlParser {
 
   }
 
+  def getOutOfOrder: Boolean = {
+    app.configuration.getBoolean("flyway.out-of-order-migrations") getOrElse true
+  }
+
 }

--- a/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
+++ b/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
@@ -63,6 +63,7 @@ class Plugin(implicit app: Application) extends play.api.Plugin
       val flyway = new Flyway
       flyway.setDataSource(new DriverDataSource(getClass.getClassLoader, configuration.driver, configuration.url, configuration.user, configuration.password))
       flyway.setLocations(migrationFilesLocation)
+      flyway.setOutOfOrder(configReader.getOutOfOrder)
       flyway.setValidateOnMigrate(validateOnMigrate(dbName))
       if (initOnMigrate(dbName)) {
         flyway.setInitOnMigrate(true)


### PR DESCRIPTION
Often times a new migration needs to be added to the middle of an
existing set of migrations in order to patch the migration
functionality. Enabling out of order migrations can be accomplished by
setting the value to true. This functionality is also helpful in a large
team when one migration is merged and deployed before another migration
created earlier by another developer is merged and deployed