### PR TITLE
Add support for placeholders in migration files

### DIFF
--- a/playapp/conf/application.conf
+++ b/playapp/conf/application.conf
@@ -47,6 +47,15 @@ db.third.url="jdbc:h2:mem:example3;DB_CLOSE_DELAY=-1"
 db.third.user="sa"
 db.third.pass="secret3"
 
+db.placeholders.driver=org.h2.Driver
+db.placeholders.url="jdbc:h2:mem:example4;db_CLOSE_DELAY=-1"
+db.placeholders.user="sa"
+db.placeholders.password="secret"
+db.placeholders.migration.placeholderPrefix="[[["
+db.placeholders.migration.placeholderSuffix="]]]"
+db.placeholders.migration.placeholders.tableName="wow"
+db.placeholders.migration.placeholders.maybe="not"
+
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed

--- a/playapp/conf/db/migration/placeholders/V1__create_wow_table.sql
+++ b/playapp/conf/db/migration/placeholders/V1__create_wow_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE [[[tableName]]] (
+    id integer primary key,
+    name varchar(200) [[[maybe]]] null
+);

--- a/playapp/conf/db/migration/placeholders/V2__add_wows.sql
+++ b/playapp/conf/db/migration/placeholders/V2__add_wows.sql
@@ -1,0 +1,1 @@
+INSERT INTO [[[tableName]]] (id, name) VALUES (1, 'Oh!');

--- a/playapp/test/PluginSpec.scala
+++ b/playapp/test/PluginSpec.scala
@@ -61,6 +61,22 @@ class PluginSpec extends FunSpec
       sql"""DROP TABLE "schema_version"""".execute.apply()
     }
 
+    NamedDB('placeholders) autoCommit { implicit session =>
+      val wows =
+        sql"SELECT * FROM wow" // This table name is substituted for a placeholder during migration
+          .map(rs => rs.int("id") -> rs.string("name"))
+          .list
+          .apply()
+
+      wows.size should be(1)
+      wows.head should be((1, "Oh!"))
+
+      sql"DROP TABLE wow".execute.apply()
+
+      // Table created by flyway
+      sql"""DROP TABLE "schema_version"""".execute.apply()
+    }
+
   }
 
   describe("Plugin") {


### PR DESCRIPTION
The placeholder prefix, suffix and key-value pairs can be specificed in application.conf, e.g.

```
db.default.migration.placeholderPrefix="$flyway{{{"
db.default.migration.placeholderSuffix="}}}"
db.default.migration.placeholders.foo="bar"
db.default.migration.placeholders.hoge="pupi"
```

This would cause

```
INSERT INTO USERS ($flyway{{{foo}}}) VALUES ('$flyway{{{hoge}}}')
```

to be rewritten to

```
INSERT INTO USERS (bar) VALUES ('pupi')
```
