### PR TITLE
Flyway 3.1

### DIFF
--- a/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
+++ b/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
@@ -83,7 +83,7 @@ class Plugin(implicit app: Application) extends play.api.Plugin
       flyway.setValidateOnMigrate(validateOnMigrate(dbName))
       flyway.setEncoding(encoding(dbName))
       if (initOnMigrate(dbName)) {
-        flyway.setInitOnMigrate(true)
+        flyway.setBaselineOnMigrate(true)
       }
       for (prefix <- placeholderPrefix(dbName)) {
         flyway.setPlaceholderPrefix(prefix)
@@ -186,8 +186,8 @@ class Plugin(implicit app: Application) extends play.api.Plugin
       }
       case versionedInitPath(dbName, version) => {
 
-        flyways.get(dbName).foreach(_.setInitVersion(version))
-        flyways.get(dbName).foreach(_.init())
+        flyways.get(dbName).foreach(_.setBaselineVersion(version))
+        flyways.get(dbName).foreach(_.baseline())
         Some(Redirect(getRedirectUrlFromRequest(request)))
       }
       case showInfoPath(dbName) => {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,13 +13,13 @@ object ApplicationBuild extends Build {
     Seq(
       name := "play-flyway",
       organization := "com.github.tototoshi",
-      version := "1.1.3",
+      version := "1.1.4-SNAPSHOT",
       scalaVersion := "2.10.4",
       crossScalaVersions := scalaVersion.value :: "2.11.1" :: Nil,
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play" % play.core.PlayVersion.current % "provided",
-        "org.flywaydb" % "flyway-core" % "3.0",
+        "org.flywaydb" % "flyway-core" % "3.1",
         scalatest
       ),
       scalacOptions ++= Seq("-language:_", "-deprecation")


### PR DESCRIPTION
Flyway 3.1 is only a minor update so I only had to fix a couple of deprecation warnings w.r.t. the `init`-methods being renamed to `baseline`.

Did I overlook anything?
