### PR TITLE
fix classloader issue for Java based migration

### DIFF
--- a/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
+++ b/plugin/src/main/scala/com/github/tototoshi/play2/flyway/Plugin.scala
@@ -110,7 +110,7 @@ class Plugin(implicit app: Application) extends play.api.Plugin
           |${readInputStreamToString(in)}""".stripMargin
     }.orElse {
       import scala.util.control.Exception._
-      allCatch opt { Class.forName(migration.getScript) } map { cls =>
+      allCatch opt { app.classloader.loadClass(migration.getScript) } map { cls =>
         s"""|--- ${migration.getScript} ---
             | (Java-based migration)""".stripMargin
       }


### PR DESCRIPTION
Play class loader is a bit tricky. We can’t rely on `Class.forName`

Fix #32 